### PR TITLE
Update affiliations for Tom A. and Alex B.

### DIFF
--- a/members_and_sponsors.md
+++ b/members_and_sponsors.md
@@ -6,8 +6,6 @@ Sponsors:
 - Microsoft
 - Google Research (note: listed logos will be TensorFlow/JAX)
 - The D. E. Shaw group
-- OmniSci
-- Anaconda
 - Quansight
 
 Members with affiliations:
@@ -24,8 +22,8 @@ Members with affiliations:
 - Adam Paszke - Google Research, PyTorch, JAX
 - Arvid Bessen - The D. E. Shaw group
 - Tiankai Tu - The D. E. Shaw group
-- Tom Augspurger - Anaconda, Dask, Pandas
-- Alex Baden - OmniSci
+- Tom Augspurger - Dask, Pandas
+- Alex Baden - OmniSciDB
 - Sheng Zha - Apache MXNet, ONNX
 - Jeff Reback - Pandas, Ibis
 - Maarten Breddels - Vaex


### PR DESCRIPTION
After writing the announcement blog post and some more conversation about the exact mechanism of sponsors and members and who we invited why, I realized we should only keep the _company_ affiliations for the people who are representing a sponsor. Everyone else's affiliation is one or more array/dataframe libraries.

@TomAugspurger and @alexbaden please let me know if this change looks fine.