### PR TITLE
Add affiliation for Leo Fang (Brookhaven Natl Lab)

### DIFF
--- a/members_and_sponsors.md
+++ b/members_and_sponsors.md
@@ -36,4 +36,4 @@ Members with affiliations:
 - Hyukjin Kwon - Apache Spark, Koalas
 - Takuya Ueshin - Apache Spark, Koalas
 - Xiao Li - Apache Spark
-- Leo Fang - CuPy
+- Leo Fang - Brookhaven National Lab, CuPy


### PR DESCRIPTION
This is following up on the discussion about acknowledging contributions from people on "day job time".

If others want to add an affiliation, please comment or send a follow-up PR.