### PR TITLE
Add new members and expand membership scope to array-consuming libraries

### DIFF
--- a/consortium_governance.md
+++ b/consortium_governance.md
@@ -42,7 +42,8 @@ Membership in the Consortium can be gained by invitation from the existing membe
 
 - A relevant open source project that falls under the scope of a Consortium
   API standard (existing or being developed). Currently this includes
-  array/tensor and dataframe libraries. What "relevant" means is hard to
+  array/tensor and dataframe libraries, and libraries that are array consumers
+  through the array API standard. What "relevant" means is hard to
   quantify in a metric; this will be decided upon by the existing Members.
 - A Consortium Sponsor (see next section).
 

--- a/members_and_sponsors.md
+++ b/members_and_sponsors.md
@@ -21,6 +21,7 @@ Members with affiliations:
 - Ashish Agarwal - Google Research, TensorFlow
 - Stephan Hoyer - Google Research, JAX, NumPy, XArray
 - Adam Paszke - Google Research, PyTorch, JAX
+- Jake Vanderplas - Google Research, JAX
 - Arvid Bessen - The D. E. Shaw group
 - Tom Augspurger - Dask, Pandas
 - Alex Baden - OmniSciDB
@@ -30,7 +31,6 @@ Members with affiliations:
 - Joris Van den Bossche - Pandas, GeoPandas, Apache Arrow
 - Ralf Gommers - Quansight, NumPy, PyTorch (_Consortium Chair_)
 - Athan Reines - Quansight
-- Stephannie Jiménez Gacha - Quansight
 - Aaron Meurer - Quansight
 - Keith Kraus - cuDF
 - Ashwin Srinath - NVIDIA, cuDF
@@ -50,3 +50,5 @@ Members with affiliations:
 - Brock Mendel - Intel, Pandas
 - Ritchie Vink - Polars
 - Stijn de Gooijer - Polars
+- Lucas Colley - SciPy
+- Evgeni Burovski - SciPy, Quansight


### PR DESCRIPTION
Closes gh-26

This addresses the current need. At some point we'll need to look at the governance doc a bit more carefully, because it hasn't been updated much after the first year of the consortium's life.

Cc @jakevdp @lucascolley @ev-br @steff456 for visibility